### PR TITLE
Fix preserving import path on Windows

### DIFF
--- a/io_converter_pix_wrapper/__init__.py
+++ b/io_converter_pix_wrapper/__init__.py
@@ -472,7 +472,7 @@ class CONV_PIX_WRAPPER_OT_ListImport(bpy.types.Operator):
         if not self.only_convert:
 
             pim_import_file = model_file_entry_name[:-4] + ".pim"
-            pim_import_dir = path_join(get_scs_globals().scs_project_path, self.model_browser_data.current_subpath[1:])
+            pim_import_dir = os.path.abspath(path_join(get_scs_globals().scs_project_path, self.model_browser_data.current_subpath[1:]))
 
             bpy.ops.scs_tools.import_pim(files=[{"name": pim_import_file}], directory=pim_import_dir)
 


### PR DESCRIPTION
On Windows whenever I import model I get this warning:
```
WARNING SUMMARY:
           ================
           > Can not preserve import path for export on import SCS Root 'cab_hi', as import was done from outside of current SCS Project Base Path!
           ================
```
It is because ConverterPIXWrapper provides path with slashes to SCS Tools, while SCS Tools expects path with backslashes.

Whenever I select SCS Project Base Path, it gets filled with backslashes:
![image](https://github.com/user-attachments/assets/8f0b0e31-61b7-4112-8368-0237ca8adf2b)

and then importing PIM files preserves import path properly. But ConverterPIXWrapper provides path with slashes, and relative path cannot be properly calculated.
Then, I cannot use slashes in SCS Project Base Path, because importing PIM breaks up (not preserving import path).
So I believe the fix is to provide import path to SCS Tools with proper slashing.